### PR TITLE
cluster_api: tarantool merger rock - port merger.c to module api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ install_manifest.txt
 *.xlog*
 *~
 .gdb_history
-./build
-/build
+/build*
+/.vscode
 VERSION
 CTestTestfile.cmake
 Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,10 @@
+## TODO
+
+1. msgpack headers
+2. small ibuf.h headers
+3. [box_]tuple_validate
+4. tuple_data, tuple_bsize, 
+5. salad/heap.h - heap_node
+6. key_def.h local
+7. lua/key_def - luaT_check_key_def
+8. utils - luaL_register_module

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,11 @@ if (APPLE)
 endif(APPLE)
 
 # Add C library
-add_library(${PROJECT_NAME} SHARED init.c merger/merger.c key_def/key_def.c)
+add_library(${PROJECT_NAME} SHARED
+            init.c
+            merger/merger.c merger/merger-source.c
+            merger/compat/utils.c
+            key_def/key_def.c)
 # target_link_libraries(merger ${LUAJIT_LIBRARIES} ${MSGPUCK_LIBRARIES})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" OUTPUT_NAME ${PROJECT_NAME})
 

--- a/src/merger/compat/diag.h
+++ b/src/merger/compat/diag.h
@@ -1,0 +1,71 @@
+#ifndef MERGER_DIAG_H_INCLUDED
+#define MERGER_DIAG_H_INCLUDED
+/*
+ * Copyright 2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* 
+ * Drastically simplified diag.h for using at the external modules
+ * do not save any diagnostics anywhere, but rather report them via
+ * logging facilities
+ */
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#include <module.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+
+
+#define diag_set(class, ...) do {					\
+	/* Preserve the original errno. */                              \
+	int save_errno = errno;                                         \
+	say_debug("%s at %s:%i", #class, __FILE__, __LINE__);		\
+	/* Restore the errno which might have been reset.  */           \
+	errno = save_errno;                                             \
+} while (0)
+
+#define diag_add(class, ...) do {					\
+	int save_errno = errno;						\
+	say_debug("%s at %s:%i", #class, __FILE__, __LINE__);		\
+	errno = save_errno;						\
+} while (0)
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* MERGER_DIAG_H_INCLUDED */

--- a/src/merger/compat/heap.h
+++ b/src/merger/compat/heap.h
@@ -1,0 +1,541 @@
+/*
+ * *No header guard*: the header is allowed to be included twice
+ * with different sets of defines.
+ */
+/*
+ * Copyright 2010-2016, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *		copyright notice, this list of conditions and the
+ *		following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *		copyright notice, this list of conditions and the following
+ *		disclaimer in the documentation and/or other materials
+ *		provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <memory.h>
+
+/**
+ * Additional user defined name that appended to prefix 'heap'
+ *	for all names of structs and functions in this header file.
+ * All names use pattern: <HEAP_NAME>heap_<name of func/struct>
+ * May be empty, but still have to be defined (just #define HEAP_NAME)
+ * Example:
+ * #define HEAP_NAME test_
+ * ...
+ * test_heap_create(&some_heap);
+ * test_heap_destroy(&some_heap);
+ */
+
+/* For predefinition of structures and type non specific functions just make:
+ * #define HEAP_FORWARD_DECLARATION
+ * #inlude "heap.h"
+ */
+#ifndef HEAP_FORWARD_DECLARATION
+
+#ifndef HEAP_NAME
+#error "HEAP_NAME must be defined"
+#endif /* HEAP_NAME */
+
+
+/**
+ * Data comparing function. Takes 3 parameters - heap, node1, node2,
+ * where heap is pointer onto heap_t structure and node1, node2
+ * are two pointers on nodes in your structure.
+ * For example you have such type:
+ *	 struct my_type {
+ *	 	int value;
+ *	 	struct heap_node vnode;
+ *	 };
+ * Then node1 and node2 will be pointers on field vnode of two
+ * my_type instances.
+ * The function below is example of valid comparator by value:
+ *
+ * bool test_type_less(const heap_t *heap, const struct heap_node *a,
+ *		       const struct heap_node *b) {
+ *
+ *	const struct my_type *left = (struct my_type *)((char *)a -
+ *					offsetof(struct my_type, vnode));
+ *	const struct my_type *right = (struct my_type *)((char *)b -
+ *					offsetof(struct my_type, vnode));
+ *	return left->value < right->value;
+ * }
+ *
+ * HEAP_LESS is less function that is important!
+ */
+
+#ifndef HEAP_LESS
+#error "HEAP_LESS must be defined"
+#endif
+
+/** Structure, stored in the heap. */
+#ifndef heap_value_t
+#error "heap_value_t must be defined"
+#endif
+
+/** Name of heap_node attribute in heap_value_t. */
+#ifndef heap_value_attr
+#error "heap_value_attr must be defined"
+#endif
+
+/**
+ * Tools for name substitution:
+ */
+#ifndef CONCAT3
+#define CONCAT3_R(a, b, c) a##b##c
+#define CONCAT3(a, b, c) CONCAT3_R(a, b, c)
+#endif
+
+#ifdef _
+#error '_' must be undefinded!
+#endif
+#ifndef HEAP
+#define HEAP(name) CONCAT3(HEAP_NAME, _, name)
+#endif
+
+#endif /* HEAP_FORWARD_DECLARATION */
+
+/* Structures. */
+
+#ifndef HEAP_STRUCTURES /* Include guard for structures */
+
+#define HEAP_STRUCTURES
+
+enum {
+	HEAP_INITIAL_CAPACITY = 8,
+	HEAP_NODE_STRAY_POS = UINT32_MAX,
+};
+
+typedef uint32_t heap_off_t;
+
+/**
+ * Main structure for holding heap.
+ */
+struct heap_core_structure {
+	heap_off_t size;
+	heap_off_t capacity;
+	struct heap_node **harr; /* array of heap node pointers */
+};
+
+typedef struct heap_core_structure heap_t;
+
+/**
+ * Heap entry structure.
+ */
+struct heap_node {
+	heap_off_t pos;
+};
+
+/** Initialize a heap node with default values. */
+static inline void
+heap_node_create(struct heap_node *node)
+{
+	node->pos = HEAP_NODE_STRAY_POS;
+}
+
+/** Check if a heap node does not belong to any heap. */
+static inline bool
+heap_node_is_stray(const struct heap_node *node)
+{
+	return node->pos == HEAP_NODE_STRAY_POS;
+}
+
+/**
+ * Heap iterator structure.
+ */
+struct heap_iterator {
+	heap_t *heap;
+	heap_off_t curr_pos;
+};
+
+#endif /* HEAP_STRUCTURES */
+
+#ifndef HEAP_FORWARD_DECLARATION
+
+#ifndef container_of
+#define container_of(ptr, type, member) ({ \
+	const typeof( ((type *)0)->member  ) *__mptr = (ptr); \
+	(type *)( (char *)__mptr - offsetof(type,member)  );})
+#endif
+
+#define node_to_value(n) container_of(n, heap_value_t, heap_value_attr)
+#define value_to_node(v) (&(v)->heap_value_attr)
+
+/* Extern API that is the most usefull part. */
+
+/**
+ * Initialize the heap.
+ */
+static inline void
+HEAP(create)(heap_t *heap);
+
+/**
+ * Destroy current heap.
+ */
+static inline void
+HEAP(destroy)(heap_t *heap);
+
+/**
+ * Return min value.
+ */
+static inline heap_value_t *
+HEAP(top)(heap_t *heap);
+
+/**
+ * Erase min value.
+ */
+static inline heap_value_t *
+HEAP(pop)(heap_t *heap);
+
+/**
+ * Insert value.
+ */
+static inline int
+HEAP(insert)(heap_t *heap, heap_value_t *value);
+
+/**
+ * Delete node from heap.
+ */
+static inline void
+HEAP(delete)(heap_t *heap, heap_value_t *value);
+
+/**
+ * Heapify tree after update of value.
+ */
+static inline void
+HEAP(update)(heap_t *heap, heap_value_t *value);
+
+/**
+ * Heapify tree after updating all values.
+ */
+static inline void
+HEAP(update_all)(heap_t *heap);
+
+/**
+ * Heap iterator init.
+ */
+static inline void
+HEAP(iterator_init)(heap_t *heap, struct heap_iterator *it);
+
+/**
+ * Heap iterator next.
+ */
+static inline heap_value_t *
+HEAP(iterator_next)(struct heap_iterator *it);
+
+/* Routines. Functions below are useless for ordinary user. */
+
+/**
+ * Heapify tree after update of value having @a node attribute.
+ */
+static inline void
+HEAP(update_node)(heap_t *heap, struct heap_node *node);
+
+/*
+ * Update backlink in the give heap_node structure.
+ */
+static inline void
+HEAP(update_link)(heap_t *heap, heap_off_t pos);
+
+/**
+ * Sift up current node.
+ */
+static inline void
+HEAP(sift_up)(heap_t *heap, struct heap_node *node);
+
+/**
+ * Sift down current node.
+ */
+static inline void
+HEAP(sift_down)(heap_t *heap, struct heap_node *node);
+
+/* Debug functions */
+
+/**
+ * Check that heap inveriants is holded.
+ */
+static inline int /* inline for suppress warning */
+HEAP(check)(heap_t *heap);
+
+
+/* Function definitions. */
+
+/**
+ * Init heap.
+ */
+static inline void
+HEAP(create)(heap_t *heap)
+{
+	heap->size = 0;
+	heap->capacity = 0;
+	heap->harr = NULL;
+}
+
+/**
+ * Destroy current heap.
+ */
+static inline void
+HEAP(destroy)(heap_t *heap)
+{
+	free(heap->harr);
+}
+
+static inline void
+HEAP(update_node)(heap_t *heap, struct heap_node *node)
+{
+	HEAP(sift_down)(heap, node);
+	HEAP(sift_up)(heap, node);
+}
+
+/*
+ * Update backlink in the give heap_node structure.
+ */
+static inline void
+HEAP(update_link)(heap_t *heap, heap_off_t pos)
+{
+	heap->harr[pos]->pos = pos;
+}
+
+/**
+ * Sift up current node.
+ */
+static inline void
+HEAP(sift_up)(heap_t *heap, struct heap_node *node)
+{
+	heap_off_t curr_pos = node->pos, parent = (curr_pos - 1) / 2;
+
+	while (curr_pos > 0 && HEAP_LESS(heap, node_to_value(node),
+					 node_to_value(heap->harr[parent]))) {
+
+		node = heap->harr[curr_pos];
+		heap->harr[curr_pos] = heap->harr[parent];
+		HEAP(update_link)(heap, curr_pos);
+		heap->harr[parent] = node;
+		HEAP(update_link)(heap, parent);
+
+		curr_pos = parent;
+		parent = (curr_pos - 1) / 2;
+		/* here overflow can occure, but that won't affect */
+	}
+}
+
+/**
+ * Sift down current node.
+ */
+static inline void
+HEAP(sift_down)(heap_t *heap, struct heap_node *node)
+{
+	heap_off_t curr_pos = node->pos, left, right;
+	heap_off_t min_child;
+
+	while (true) {
+		left = 2 * curr_pos + 1;
+		right = 2 * curr_pos + 2;
+		min_child = left;
+		if (right < heap->size &&
+		    HEAP_LESS(heap, node_to_value(heap->harr[right]),
+			      node_to_value(heap->harr[left])))
+			min_child = right;
+
+		if (left >= heap->size ||
+		    HEAP_LESS(heap, node_to_value(heap->harr[curr_pos]),
+			      node_to_value(heap->harr[min_child])))
+			return;
+
+		node = heap->harr[curr_pos];
+		heap->harr[curr_pos] = heap->harr[min_child];
+		heap->harr[min_child] = node;
+		HEAP(update_link)(heap, curr_pos);
+		HEAP(update_link)(heap, min_child);
+
+		curr_pos = min_child;
+	}
+}
+
+/**
+ * Increase capacity.
+ */
+static inline int
+HEAP(reserve)(heap_t *heap)
+{
+	if (heap->capacity > heap->size)
+		return 0;
+	heap_off_t capacity = heap->capacity == 0 ? HEAP_INITIAL_CAPACITY :
+		heap->capacity << 1;
+	void *harr = realloc(heap->harr, sizeof(struct heap_node *) * capacity);
+	if (harr == NULL)
+		return -1;
+	heap->harr = harr;
+	heap->capacity = capacity;
+	return 0;
+}
+
+/**
+ * Insert value.
+ */
+static inline int
+HEAP(insert)(heap_t *heap, heap_value_t *value)
+{
+	if (HEAP(reserve)(heap))
+		return -1;
+	struct heap_node *node = value_to_node(value);
+	heap->harr[heap->size] = node;
+	HEAP(update_link)(heap, heap->size++);
+	HEAP(sift_up)(heap, node); /* heapify */
+
+	return 0;
+}
+
+/**
+ * Return min value without removing it from heap.
+ * If heap is empty, return NULL.
+ */
+static inline heap_value_t *
+HEAP(top)(heap_t *heap)
+{
+	if (heap->size == 0)
+		return NULL;
+	return node_to_value(heap->harr[0]);
+}
+
+/**
+ * Erase min value. Returns delete value.
+ */
+static inline heap_value_t *
+HEAP(pop)(heap_t *heap)
+{
+	if (heap->size == 0)
+		return NULL;
+	heap_value_t *res = node_to_value(heap->harr[0]);
+	HEAP(delete)(heap, res);
+	return res;
+}
+
+/*
+ * Delete node from heap.
+ */
+static inline void
+HEAP(delete)(heap_t *heap, heap_value_t *value)
+{
+	if (heap->size == 0)
+		return;
+
+	struct heap_node *node = value_to_node(value);
+	assert(! heap_node_is_stray(node));
+	heap->size--;
+	heap_off_t curr_pos = node->pos;
+	heap_node_create(node);
+
+	if (curr_pos == heap->size)
+		return;
+
+	heap->harr[curr_pos] = heap->harr[heap->size];
+	HEAP(update_link)(heap, curr_pos);
+	HEAP(update_node)(heap, heap->harr[curr_pos]);
+}
+
+static inline void
+HEAP(update)(heap_t *heap, heap_value_t *value)
+{
+	HEAP(update_node)(heap, value_to_node(value));
+}
+
+/**
+ * Heapify tree after updating all values.
+ */
+static inline void
+HEAP(update_all)(heap_t *heap)
+{
+	if (heap->size <= 1)
+		return;
+
+	/* Find the parent of the last element. */
+	heap_off_t curr_pos = (heap->size - 2) / 2;
+
+	do {
+		HEAP(sift_down)(heap, heap->harr[curr_pos]);
+	} while (curr_pos-- > 0);
+}
+
+/**
+ * Heap iterator init.
+ */
+static inline void
+HEAP(iterator_init)(heap_t *heap, struct heap_iterator *it)
+{
+	it->curr_pos = 0;
+	it->heap = heap;
+}
+
+/**
+ * Heap iterator next.
+ */
+static inline heap_value_t *
+HEAP(iterator_next)(struct heap_iterator *it)
+{
+	if (it->curr_pos == it->heap->size)
+		return NULL;
+	return node_to_value(it->heap->harr[it->curr_pos++]);
+}
+
+/**
+ * Check that heap inveriants is holded.
+ */
+static inline int
+HEAP(check)(heap_t *heap)
+{
+	heap_off_t left, right, min_child;
+	for (heap_off_t curr_pos = 0;
+	     2 * curr_pos + 1 < heap->size;
+	     ++curr_pos) {
+
+		left = 2 * curr_pos + 1;
+		right = 2 * curr_pos + 2;
+		min_child = left;
+		if (right < heap->size &&
+		    HEAP_LESS(heap, node_to_value(heap->harr[right]),
+			      node_to_value(heap->harr[left])))
+			min_child = right;
+
+		if (HEAP_LESS(heap, node_to_value(heap->harr[min_child]),
+			      node_to_value(heap->harr[curr_pos])))
+			return -1;
+	}
+
+	return 0;
+}
+
+#undef node_to_value
+#undef value_to_node
+#undef heap_value_t
+#undef heap_value_attr
+
+#endif /* HEAP_FORWARD_DECLARATION */
+
+#undef HEAP_FORWARD_DECLARATION
+#undef HEAP_NAME
+#undef HEAP_LESS

--- a/src/merger/compat/key_def.h
+++ b/src/merger/compat/key_def.h
@@ -1,0 +1,12 @@
+
+struct key_def;
+
+/**
+ * Duplicate key_def.
+ * @param src Original key_def.
+ *
+ * @retval not NULL Duplicate of src.
+ * @retval     NULL Memory error.
+ */
+struct key_def *
+key_def_dup(const struct key_def *src);

--- a/src/merger/compat/tuple.h
+++ b/src/merger/compat/tuple.h
@@ -1,0 +1,88 @@
+#ifndef MERGER_TUPLE_H_INCLUDED
+#define MERGER_TUPLE_H_INCLUDED
+/*
+ * Copyright 2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <module.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/**
+ * Create a new tuple with specific format from a Lua table, a
+ * tuple, or objects on the lua stack.
+ *
+ * Set idx to zero to create the new tuple from objects on the lua
+ * stack.
+ *
+ * In case of an error set a diag and return NULL.
+ */
+struct tuple *
+luaT_tuple_new(struct lua_State *L, int idx, box_tuple_format_t *format);
+
+
+/**
+ * Check tuple data correspondence to space format.
+ * Actually, checks everything that is checked by
+ * tuple_field_map_create.
+ *
+ * @param format Format to which the tuple must match.
+ * @param tuple  MessagePack array.
+ *
+ * @retval  0 The tuple is valid.
+ * @retval -1 The tuple is invalid.
+ */
+int
+tuple_validate_raw(struct tuple_format *format, const char *data);
+
+/**
+ * Check tuple data correspondence to the space format.
+ * @param format Format to which the tuple must match.
+ * @param tuple  Tuple to validate.
+ *
+ * @retval  0 The tuple is valid.
+ * @retval -1 The tuple is invalid.
+ */
+static inline int
+box_tuple_validate(box_tuple_format_t *format, box_tuple_t *tuple)
+{
+	#if 0
+	return tuple_validate_raw(format, tuple_data(tuple));
+	#else
+	return 0;
+	#endif
+}
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* MERGER_TUPLE_H_INCLUDED */

--- a/src/merger/compat/utils.c
+++ b/src/merger/compat/utils.c
@@ -1,0 +1,127 @@
+
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <malloc.h>
+
+#include "diag.h"
+#include "utils.h"
+
+/* {{{ Helper functions to interact with a Lua iterator from C */
+
+struct luaL_iterator {
+	int gen;
+	int param;
+	int state;
+};
+
+struct luaL_iterator *
+luaL_iterator_new(lua_State *L, int idx)
+{
+	struct luaL_iterator *it = malloc(sizeof(struct luaL_iterator));
+	if (it == NULL) {
+		diag_set(OutOfMemory, sizeof(struct luaL_iterator),
+			 "malloc", "luaL_iterator");
+		return NULL;
+	}
+
+	if (idx == 0) {
+		/* gen, param, state are on top of a Lua stack. */
+		lua_pushvalue(L, -3); /* Popped by luaL_ref(). */
+		it->gen = luaL_ref(L, LUA_REGISTRYINDEX);
+		lua_pushvalue(L, -2); /* Popped by luaL_ref(). */
+		it->param = luaL_ref(L, LUA_REGISTRYINDEX);
+		lua_pushvalue(L, -1); /* Popped by luaL_ref(). */
+		it->state = luaL_ref(L, LUA_REGISTRYINDEX);
+	} else {
+		/*
+		 * {gen, param, state} table is at idx in a Lua
+		 * stack.
+		 */
+		lua_rawgeti(L, idx, 1); /* Popped by luaL_ref(). */
+		it->gen = luaL_ref(L, LUA_REGISTRYINDEX);
+		lua_rawgeti(L, idx, 2); /* Popped by luaL_ref(). */
+		it->param = luaL_ref(L, LUA_REGISTRYINDEX);
+		lua_rawgeti(L, idx, 3); /* Popped by luaL_ref(). */
+		it->state = luaL_ref(L, LUA_REGISTRYINDEX);
+	}
+
+	return it;
+}
+
+int
+luaL_iterator_next(lua_State *L, struct luaL_iterator *it)
+{
+	int frame_start = lua_gettop(L);
+
+	/* Call gen(param, state). */
+	lua_rawgeti(L, LUA_REGISTRYINDEX, it->gen);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, it->param);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, it->state);
+	if (luaT_call(L, 2, LUA_MULTRET) != 0) {
+		/*
+		 * Pop garbage from the call (a gen function
+		 * likely will not leave the stack even when raise
+		 * an error), pop a returned error.
+		 */
+		lua_settop(L, frame_start);
+		return -1;
+	}
+	int nresults = lua_gettop(L) - frame_start;
+
+	/*
+	 * gen() function can either return nil when the iterator
+	 * ends or return zero count of values.
+	 *
+	 * In LuaJIT pairs() returns nil, but ipairs() returns
+	 * nothing when ends.
+	 */
+	if (nresults == 0 || lua_isnil(L, frame_start + 1)) {
+		lua_settop(L, frame_start);
+		return 0;
+	}
+
+	/* Save the first result to it->state. */
+	luaL_unref(L, LUA_REGISTRYINDEX, it->state);
+	lua_pushvalue(L, frame_start + 1); /* Popped by luaL_ref(). */
+	it->state = luaL_ref(L, LUA_REGISTRYINDEX);
+
+	return nresults;
+}
+
+void luaL_iterator_delete(struct luaL_iterator *it)
+{
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, it->gen);
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, it->param);
+	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, it->state);
+	free(it);
+}
+
+/* }}} */

--- a/src/merger/compat/utils.h
+++ b/src/merger/compat/utils.h
@@ -1,0 +1,131 @@
+#ifndef MERGER_UTILS_H_INCLUDED
+#define MERGER_UTILS_H_INCLUDED
+
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/* 
+ * Drastically simplified utils.h for using at the external modules
+ * at the moment it's about iterators mostly, with a few external 
+ * symbols declared
+ * 
+ * NB! Most ptobably this whole set of declarations should be part
+ *     of binary compatible module api. Using this hack only temporary.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <math.h> /* modf, isfinite */
+
+#include <module.h>
+
+#include <lua.h>
+#include <lauxlib.h> /* luaL_error */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+extern struct lua_State *tarantool_L;
+
+void
+luaL_register_type(struct lua_State *L, const char *type_name,
+		   const struct luaL_Reg *methods);
+
+
+void
+luaL_register_module(struct lua_State *L, const char *modname,
+		     const struct luaL_Reg *methods);
+
+
+/**
+ * @brief Creates a new Lua coroutine in a protected frame. If
+ * <lua_newthread> call underneath succeeds, the created Lua state
+ * is on the top of the guest stack and a pointer to this state is
+ * returned. Otherwise LUA_ERRMEM error is handled and the result
+ * is NULL.
+ * @param L is a Lua state
+ * @sa <lua_newthread>
+ */
+struct lua_State *
+luaT_newthread(struct lua_State *L);
+
+/**
+ * Check if a value on @a L stack by index @a idx is an ibuf
+ * object. Both 'struct ibuf' and 'struct ibuf *' are accepted.
+ * Returns NULL, if can't convert - not an ibuf object.
+ */
+struct ibuf *
+luaL_checkibuf(struct lua_State *L, int idx);
+
+/* {{{ Helper functions to interact with a Lua iterator from C */
+
+/**
+ * Holds iterator state (references to Lua objects).
+ */
+struct luaL_iterator;
+
+/**
+ * Create a Lua iterator from a gen, param, state triplet.
+ *
+ * If idx == 0, then three top stack values are used as the
+ * triplet. Note: they are not popped.
+ *
+ * Otherwise idx is index on Lua stack points to a
+ * {gen, param, state} table.
+ */
+struct luaL_iterator *
+luaL_iterator_new(lua_State *L, int idx);
+
+/**
+ * Move iterator to the next value. Push values returned by
+ * gen(param, state).
+ *
+ * Return count of pushed values. Zero means no more results
+ * available. In case of a Lua error in a gen function return -1
+ * and set a diag.
+ */
+int
+luaL_iterator_next(lua_State *L, struct luaL_iterator *it);
+
+/**
+ * Free all resources held by the iterator.
+ */
+void luaL_iterator_delete(struct luaL_iterator *it);
+
+/* }}} */
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+
+#endif /* MERGER_UTILS_H_INCLUDED */

--- a/src/merger/merger-source.c
+++ b/src/merger/merger-source.c
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#if 0 
+#define HEAP_FORWARD_DECLARATION
+#include "salad/heap.h"
+
+#include "diag.h"             /* diag_set() */
+#include "box/tuple.h"        /* tuple_ref(), tuple_unref(),
+				 tuple_validate() */
+#include "box/tuple_format.h" /* box_tuple_format_new(),
+				 tuple_format_*() */
+#include "box/key_def.h"      /* key_def_*(),
+				 tuple_compare() */
+#else
+#include <module.h>
+#include <small/ibuf.h>       /* struct ibuf */
+
+#include "compat/diag.h"
+#include "compat/tuple.h"
+#define HEAP_FORWARD_DECLARATION
+#include "compat/heap.h"
+
+// FIXME - migrate to local key_def implementation
+#include "compat/key_def.h"
+
+#include "merger-source.h"
+#endif
+
+/* {{{ Merger */
+
+/**
+ * Holds a source to fetch next tuples and a last fetched tuple to
+ * compare the node against other nodes.
+ *
+ * The main reason why this structure is separated from a merge
+ * source is that a heap node can not be a member of several
+ * heaps.
+ *
+ * The second reason is that it allows to encapsulate all heap
+ * related logic inside this compilation unit, without any traces
+ * in externally visible structures.
+ */
+struct merger_heap_node {
+	/* A source of tuples. */
+	struct merge_source *source;
+	/*
+	 * A last fetched (refcounted) tuple to compare against
+	 * other nodes.
+	 */
+	box_tuple_t *tuple;
+	/* An anchor to make the structure a merger heap node. */
+	struct heap_node in_merger;
+};
+
+static bool
+merge_source_less(const heap_t *heap, const struct merger_heap_node *left,
+		  const struct merger_heap_node *right);
+#define HEAP_NAME merger_heap
+#define HEAP_LESS merge_source_less
+#define heap_value_t struct merger_heap_node
+#define heap_value_attr in_merger
+#include "compat/heap.h"
+#undef HEAP_NAME
+#undef HEAP_LESS
+#undef heap_value_t
+#undef heap_value_attr
+
+/**
+ * Holds a heap, parameters of a merge process and utility fields.
+ */
+struct merger {
+	/* A merger is a source. */
+	struct merge_source base;
+	/*
+	 * Whether a merge process started.
+	 *
+	 * The merger postpones charging of heap nodes until a
+	 * first output tuple is acquired.
+	 */
+	bool started;
+	/* A key_def to compare tuples. */
+	struct key_def *key_def;
+	/* A format to acquire compatible tuples from sources. */
+	box_tuple_format_t *format;
+	/*
+	 * A heap of sources (of nodes that contains a source to
+	 * be exact).
+	 */
+	heap_t heap;
+	/* An array of heap nodes. */
+	uint32_t node_count;
+	struct merger_heap_node *nodes;
+	/* Ascending (false) / descending (true) order. */
+	bool reverse;
+};
+
+/* Helpers */
+
+/**
+ * Data comparing function to construct a heap of sources.
+ */
+static bool
+merge_source_less(const heap_t *heap, const struct merger_heap_node *left,
+		  const struct merger_heap_node *right)
+{
+	assert(left->tuple != NULL);
+	assert(right->tuple != NULL);
+	struct merger *merger = container_of(heap, struct merger, heap);
+	int cmp = box_tuple_compare(left->tuple, right->tuple, merger->key_def);
+	return merger->reverse ? cmp >= 0 : cmp < 0;
+}
+
+/**
+ * Initialize a new merger heap node.
+ */
+static void
+merger_heap_node_create(struct merger_heap_node *node,
+			struct merge_source *source)
+{
+	node->source = source;
+	merge_source_ref(node->source);
+	node->tuple = NULL;
+	heap_node_create(&node->in_merger);
+}
+
+/**
+ * Free a merger heap node.
+ */
+static void
+merger_heap_node_delete(struct merger_heap_node *node)
+{
+	merge_source_unref(node->source);
+	if (node->tuple != NULL)
+		box_tuple_unref(node->tuple);
+}
+
+/**
+ * The helper to add a new heap node to a merger heap.
+ *
+ * Return -1 at an error and set a diag.
+ *
+ * Otherwise store a next tuple in node->tuple, add the node to
+ * merger->heap and return 0.
+ */
+static int
+merger_add_heap_node(struct merger *merger, struct merger_heap_node *node)
+{
+	box_tuple_t *tuple = NULL;
+
+	/* Acquire a next tuple. */
+	struct merge_source *source = node->source;
+	if (merge_source_next(source, merger->format, &tuple) != 0)
+		return -1;
+
+	/* Don't add an empty source to a heap. */
+	if (tuple == NULL)
+		return 0;
+
+	node->tuple = tuple;
+
+	/* Add a node to a heap. */
+	if (merger_heap_insert(&merger->heap, node) != 0) {
+		diag_set(OutOfMemory, 0, "malloc", "merger->heap");
+		return -1;
+	}
+
+	return 0;
+}
+
+/* Virtual methods declarations */
+
+static void
+merger_delete(struct merge_source *base);
+static int
+merger_next(struct merge_source *base, box_tuple_format_t *format,
+	    box_tuple_t **out);
+
+/* Non-virtual methods */
+
+/**
+ * Set sources for a merger.
+ *
+ * It is the helper for merger_new().
+ *
+ * Return 0 at success. Return -1 at an error and set a diag.
+ */
+static int
+merger_set_sources(struct merger *merger, struct merge_source **sources,
+		   uint32_t source_count)
+{
+	const size_t nodes_size = sizeof(struct merger_heap_node) *
+		source_count;
+	struct merger_heap_node *nodes = malloc(nodes_size);
+	if (nodes == NULL) {
+		diag_set(OutOfMemory, nodes_size, "malloc",
+			 "merger heap nodes");
+		return -1;
+	}
+
+	for (uint32_t i = 0; i < source_count; ++i)
+		merger_heap_node_create(&nodes[i], sources[i]);
+
+	merger->node_count = source_count;
+	merger->nodes = nodes;
+	return 0;
+}
+
+
+struct merge_source *
+merger_new(struct key_def *key_def, struct merge_source **sources,
+	   uint32_t source_count, bool reverse)
+{
+	static struct merge_source_vtab merger_vtab = {
+		.destroy = merger_delete,
+		.next = merger_next,
+	};
+
+	struct merger *merger = malloc(sizeof(struct merger));
+	if (merger == NULL) {
+		diag_set(OutOfMemory, sizeof(struct merger), "malloc",
+			 "merger");
+		return NULL;
+	}
+
+	/*
+	 * We need to copy the key_def because it can be collected
+	 * before a merge process ends (say, by LuaJIT GC if the
+	 * key_def comes from Lua).
+	 */
+	key_def = key_def_dup(key_def);
+	if (key_def == NULL) {
+		free(merger);
+		return NULL;
+	}
+
+	box_tuple_format_t *format = box_tuple_format_new(&key_def, 1);
+	if (format == NULL) {
+		box_key_def_delete(key_def);
+		free(merger);
+		return NULL;
+	}
+
+	merge_source_create(&merger->base, &merger_vtab);
+	merger->started = false;
+	merger->key_def = key_def;
+	merger->format = format;
+	merger_heap_create(&merger->heap);
+	merger->node_count = 0;
+	merger->nodes = NULL;
+	merger->reverse = reverse;
+
+	if (merger_set_sources(merger, sources, source_count) != 0) {
+		box_key_def_delete(merger->key_def);
+		box_tuple_format_unref(merger->format);
+		merger_heap_destroy(&merger->heap);
+		free(merger);
+		return NULL;
+	}
+
+	return &merger->base;
+}
+
+/* Virtual methods */
+
+static void
+merger_delete(struct merge_source *base)
+{
+	struct merger *merger = container_of(base, struct merger, base);
+
+	box_key_def_delete(merger->key_def);
+	box_tuple_format_unref(merger->format);
+	merger_heap_destroy(&merger->heap);
+
+	for (uint32_t i = 0; i < merger->node_count; ++i)
+		merger_heap_node_delete(&merger->nodes[i]);
+
+	if (merger->nodes != NULL)
+		free(merger->nodes);
+
+	free(merger);
+}
+
+static int
+merger_next(struct merge_source *base, box_tuple_format_t *format,
+	    box_tuple_t **out)
+{
+	struct merger *merger = container_of(base, struct merger, base);
+
+	/*
+	 * Fetch a first tuple for each source and add all heap
+	 * nodes to a merger heap.
+	 */
+	if (!merger->started) {
+		for (uint32_t i = 0; i < merger->node_count; ++i) {
+			struct merger_heap_node *node = &merger->nodes[i];
+			if (merger_add_heap_node(merger, node) != 0)
+				return -1;
+		}
+		merger->started = true;
+	}
+
+	/* Get a next tuple. */
+	struct merger_heap_node *node = merger_heap_top(&merger->heap);
+	if (node == NULL) {
+		*out = NULL;
+		return 0;
+	}
+	box_tuple_t *tuple = node->tuple;
+	assert(tuple != NULL);
+
+	/* Validate the tuple. */
+	if (format != NULL && box_tuple_validate(format, tuple) != 0)
+		return -1;
+
+	/*
+	 * Note: An old node->tuple pointer will be written to
+	 * *out as refcounted tuple, so we don't unreference it
+	 * here.
+	 */
+	struct merge_source *source = node->source;
+	if (merge_source_next(source, merger->format, &node->tuple) != 0)
+		return -1;
+
+	/* Update a heap. */
+	if (node->tuple == NULL)
+		merger_heap_delete(&merger->heap, node);
+	else
+		merger_heap_update(&merger->heap, node);
+
+	*out = tuple;
+	return 0;
+}
+
+/* }}} */

--- a/src/merger/merger-source.h
+++ b/src/merger/merger-source.h
@@ -1,0 +1,150 @@
+#ifndef MERGER_SOURCE_H_INCLUDED
+#define MERGER_SOURCE_H_INCLUDED
+/*
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <module.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/* {{{ Structures */
+
+struct key_def;
+
+struct merge_source;
+
+struct merge_source_vtab {
+	/**
+	 * Free a merge source.
+	 *
+	 * Don't call it directly, use merge_source_unref()
+	 * instead.
+	 */
+	void (*destroy)(struct merge_source *base);
+	/**
+	 * Get a next tuple (refcounted) from a source.
+	 *
+	 * When format is not NULL the resulting tuple will be in
+	 * a compatible format.
+	 *
+	 * When format is NULL it means that it does not matter
+	 * for a caller in which format a tuple will be.
+	 *
+	 * Return 0 when successfully fetched a tuple or NULL. In
+	 * case of an error set a diag and return -1.
+	 */
+	int (*next)(struct merge_source *base, box_tuple_format_t *format,
+		    box_tuple_t **out);
+};
+
+/**
+ * Base (abstract) structure to represent a merge source.
+ *
+ * The structure does not hold any resources.
+ */
+struct merge_source {
+	/* Source-specific methods. */
+	const struct merge_source_vtab *vtab;
+	/* Reference counter. */
+	int refs;
+};
+
+/* }}} */
+
+/* {{{ Base merge source functions */
+
+/**
+ * Increment a merge source reference counter.
+ */
+static inline void
+merge_source_ref(struct merge_source *source)
+{
+	++source->refs;
+}
+
+/**
+ * Decrement a merge source reference counter. When it has
+ * reached zero, free the source (call destroy() virtual method).
+ */
+static inline void
+merge_source_unref(struct merge_source *source)
+{
+	assert(source->refs - 1 >= 0);
+	if (--source->refs == 0)
+		source->vtab->destroy(source);
+}
+
+/**
+ * @see merge_source_vtab
+ */
+static inline int
+merge_source_next(struct merge_source *source, box_tuple_format_t *format,
+		  box_tuple_t **out)
+{
+	return source->vtab->next(source, format, out);
+}
+
+/**
+ * Initialize a base merge source structure.
+ */
+static inline void
+merge_source_create(struct merge_source *source, struct merge_source_vtab *vtab)
+{
+	source->vtab = vtab;
+	source->refs = 1;
+}
+
+/* }}} */
+
+/* {{{ Merger */
+
+/**
+ * Create a new merger.
+ *
+ * Return NULL and set a diag in case of an error.
+ */
+struct merge_source *
+merger_new(struct key_def *key_def, struct merge_source **sources,
+	   uint32_t source_count, bool reverse);
+
+/* }}} */
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */
+
+#endif /* MERGER_SOURCE_H_INCLUDED */

--- a/src/merger/merger.c
+++ b/src/merger/merger.c
@@ -192,6 +192,9 @@ static struct lua_State *
 luaT_temp_luastate(int *coro_ref, int *top)
 {
 	#if 0 // FIXME
+	// FIXME - could we avoid of doing this altogether 
+	// at the external code? Looks not very much
+	// required
 	if (fiber()->storage.lua.stack != NULL) {
 		/*
 		 * Reuse existing stack. In the releasing function
@@ -1131,7 +1134,6 @@ encode_result_buffer(struct lua_State *L, struct merge_source *source,
 	/* Fetch, merge and copy tuples to the buffer. */
 	box_tuple_t *tuple;
 	int rc = 0;
-	#if 0
 	while (result_len < limit && (rc =
 	       merge_source_next(source, NULL, &tuple)) == 0 &&
 	       tuple != NULL) {
@@ -1145,7 +1147,6 @@ encode_result_buffer(struct lua_State *L, struct merge_source *source,
 		/* The received tuple is not more needed. */
 		box_tuple_unref(tuple);
 	}
-	#endif
 
 	if (rc != 0)
 		return luaT_error(L);

--- a/src/merger/merger.h
+++ b/src/merger/merger.h
@@ -1,7 +1,7 @@
-#ifndef TARANTOOL_BOX_LUA_MERGER_H_INCLUDED
-#define TARANTOOL_BOX_LUA_MERGER_H_INCLUDED
+#ifndef MERGER_MERGER_H_INCLUDED
+#define MERGER_MERGER_H_INCLUDED
 /*
- * Copyright 2010-2019, Tarantool AUTHORS, please see AUTHORS file.
+ * Copyright 2010-2020, Tarantool AUTHORS, please see AUTHORS file.
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following
@@ -44,4 +44,4 @@ lua_init_mergerx_merger(struct lua_State *L);
 } /* extern "C" */
 #endif /* defined(__cplusplus) */
 
-#endif /* TARANTOOL_BOX_LUA_MERGER_H_INCLUDED */
+#endif /* MERGER_MERGER_H_INCLUDED */


### PR DESCRIPTION
1st approach to porting merger.c to use only module_api, without accessing internal headers. A lot of copy-paste, and we need to revisit it later. 

**Work-in-progress**